### PR TITLE
Remove use of apt-key when installing latest git (and fix OS where it's done)

### DIFF
--- a/home/.chezmoiscripts/run_once_before_01-install-latest-git.sh.tmpl
+++ b/home/.chezmoiscripts/run_once_before_01-install-latest-git.sh.tmpl
@@ -16,10 +16,6 @@
 # */ -}}
 # {{- if (and (not .is_codespaces) .is_ubuntu) -}}
 # Set up the APT repository to get the latest version of git.
-# A1715D88E1DF1F24 is the signing key for the git PPA itself, the others
-# are dependencies (I think).
-# sudo apt-key adv --recv-keys --keyserver keyserver.ubuntu.com \
-#     A1715D88E1DF1F24 40976EAF437D05B5 3B4FE6ACC0B21F32 A6616109451BBBF2;
 sudo apt-get install --yes software-properties-common; # Contains 'add-apt-repository'
 sudo add-apt-repository --yes ppa:git-core/ppa;
 


### PR DESCRIPTION
- I was getting annoyed by the `apt-key` deprecated messages I was getting because of the setup. Stopping its use in favor of (the automated) more modern alternatives (i.e. keys are stored in individual keyring files under `/etc/apt/trusted.gpg.d/` so they can be individually referenced for which packages they sign) was also a good thing. `add-apt-repository` apparently does the right thing on its own now.
- Copilot told me that PPAs are a Ubuntu concept, they don't apply in Debian (which wasn't using it anyway, I checked the RaspberryPi), so fixed that.