### PR TITLE
Add post-apply verification to CI

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -36,6 +36,9 @@ jobs:
         run: |
           chezmoi apply --debug
 
+      - name: Verify applied dotfiles
+        run: bash tests/verify-unix.sh
+
   test-windows:
     name: Test fresh Windows install
     runs-on: windows-latest
@@ -79,6 +82,10 @@ jobs:
         run: |
           chezmoi apply --debug
 
+      - name: Verify applied dotfiles
+        shell: pwsh
+        run: ./tests/verify-windows.ps1
+
   test-linux-arm64:
     name: Test fresh Linux ARM64 install (Raspberry Pi)
     runs-on: ubuntu-24.04-arm
@@ -102,3 +109,6 @@ jobs:
       - name: Apply dotfiles
         run: |
           chezmoi apply --debug
+
+      - name: Verify applied dotfiles
+        run: bash tests/verify-unix.sh

--- a/tests/verify-unix.sh
+++ b/tests/verify-unix.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Post-apply verification for Unix targets.
+#
+# Asserts that `chezmoi apply` produced the files we expect, rather than just
+# checking that the command exited 0. This exercises three things the CI smoke
+# test otherwise can't see: template rendering, external downloads, and the
+# platform isolation logic in .chezmoiignore.
+#
+# Run from the repo root: bash tests/verify-unix.sh
+# Not '-e': we want every assertion to run so a single failure doesn't hide the rest.
+set -uo pipefail
+
+failures=0
+
+pass() { printf '  ok   %s\n' "$1"; }
+fail() {
+  printf '  FAIL %s\n' "$1"
+  failures=$((failures + 1))
+}
+
+assert_exists() {
+  if [ -e "$1" ]; then pass "$2"; else fail "$2 -- missing: $1"; fi
+}
+
+assert_executable() {
+  if [ -x "$1" ]; then pass "$2"; else fail "$2 -- not executable: $1"; fi
+}
+
+assert_absent() {
+  if [ ! -e "$1" ]; then pass "$2"; else fail "$2 -- should not exist: $1"; fi
+}
+
+assert_contains() {
+  if [ -f "$1" ] && grep -q "$2" "$1"; then
+    pass "$3"
+  else
+    fail "$3 -- pattern '$2' not found in: $1"
+  fi
+}
+
+echo "Managed dotfiles:"
+assert_exists   "${HOME}/.gitconfig"                              ".gitconfig applied"
+assert_contains "${HOME}/.gitconfig" "716334+alexvy86"           ".gitconfig rendered from template"
+assert_exists   "${HOME}/.gitconfig-maintenance"                  ".gitconfig-maintenance created"
+assert_exists   "${HOME}/.bashrc"                                 ".bashrc applied"
+assert_exists   "${HOME}/.zshrc"                                  ".zshrc applied"
+assert_exists   "${HOME}/.zshenv"                                 ".zshenv applied"
+assert_exists   "${HOME}/.profile"                                ".profile applied"
+assert_exists   "${HOME}/.config/git/ignore"                      "global gitignore applied"
+assert_exists   "${HOME}/.config/git.sh"                          "git.sh shell snippet applied"
+assert_exists   "${HOME}/.claude/CLAUDE.md"                       "Claude config applied"
+assert_exists   "${HOME}/.oh-my-zsh/custom/themes/alex.zsh-theme" "custom zsh theme applied"
+
+echo "Externals:"
+assert_exists     "${HOME}/.local/share/navi/cheats/git.cheat" "navi git cheat downloaded"
+assert_exists     "${HOME}/.local/bin/ssh-ident"              "ssh-ident downloaded"
+assert_executable "${HOME}/.local/bin/ssh-ident"              "ssh-ident is executable"
+assert_exists     "${HOME}/.config/zsh/zsh-autocomplete"      "zsh-autocomplete cloned"
+assert_exists     "${HOME}/.config/zsh/fzf-tab"               "fzf-tab cloned"
+
+echo "Cross-platform isolation (Windows-only files absent):"
+assert_absent "${HOME}/AppData"                    "AppData not applied on Unix"
+assert_absent "${HOME}/.config/powertoys.dsc.yaml" "PowerToys config not applied on Unix"
+
+echo
+if [ "${failures}" -gt 0 ]; then
+  printf '%s assertion(s) failed.\n' "${failures}"
+  exit 1
+fi
+echo "All assertions passed."

--- a/tests/verify-windows.ps1
+++ b/tests/verify-windows.ps1
@@ -1,0 +1,72 @@
+# Post-apply verification for Windows targets.
+#
+# Asserts that `chezmoi apply` produced the files we expect, rather than just
+# checking that the command exited 0. This exercises three things the CI smoke
+# test otherwise can't see: template rendering, external downloads, and the
+# platform isolation logic in .chezmoiignore.
+#
+# Run from the repo root: pwsh ./tests/verify-windows.ps1
+# We collect every failure instead of stopping at the first so one miss doesn't hide the rest.
+$ErrorActionPreference = 'Stop'
+$script:Failures = 0
+
+function Assert-Exists {
+  param([string]$Path, [string]$Description)
+  if (Test-Path -LiteralPath $Path) {
+    Write-Host "  ok   $Description" -ForegroundColor Green
+  } else {
+    Write-Host "  FAIL $Description -- missing: $Path" -ForegroundColor Red
+    $script:Failures++
+  }
+}
+
+function Assert-Absent {
+  param([string]$Path, [string]$Description)
+  if (-not (Test-Path -LiteralPath $Path)) {
+    Write-Host "  ok   $Description" -ForegroundColor Green
+  } else {
+    Write-Host "  FAIL $Description -- should not exist: $Path" -ForegroundColor Red
+    $script:Failures++
+  }
+}
+
+function Assert-Contains {
+  param([string]$Path, [string]$Pattern, [string]$Description)
+  if ((Test-Path -LiteralPath $Path) -and (Select-String -LiteralPath $Path -Pattern $Pattern -Quiet)) {
+    Write-Host "  ok   $Description" -ForegroundColor Green
+  } else {
+    Write-Host "  FAIL $Description -- pattern '$Pattern' not found in: $Path" -ForegroundColor Red
+    $script:Failures++
+  }
+}
+
+$h = $env:USERPROFILE
+
+Write-Host "Managed dotfiles:"
+Assert-Exists   "$h\.gitconfig"                       ".gitconfig applied"
+Assert-Contains "$h\.gitconfig" "716334\+alexvy86"    ".gitconfig rendered from template"
+Assert-Exists   "$h\.gitconfig-maintenance"           ".gitconfig-maintenance created"
+Assert-Exists   "$h\.bashrc"                          ".bashrc applied (kept on Windows for GitBash)"
+Assert-Exists   "$h\.config\git\ignore"               "global gitignore applied"
+Assert-Exists   "$h\.claude\CLAUDE.md"                "Claude config applied"
+Assert-Exists   "$h\.config\powershell\profile.ps1"   "PowerShell profile applied"
+
+Write-Host "Windows-specific files:"
+Assert-Exists "$h\AppData\Roaming\navi\config.yaml"      "navi config applied"
+Assert-Exists "$h\AppData\Roaming\navi\cheats\git.cheat" "navi git cheat downloaded"
+Assert-Exists "$h\AppData\Roaming\nushell\config.nu"     "nushell config applied"
+Assert-Exists "$h\AppData\Roaming\nushell\nu_scripts"    "nu_scripts cloned"
+Assert-Exists "$h\AppData\Local\Packages\Microsoft.WindowsTerminal_8wekyb3d8bbwe\LocalState\settings.json" "Windows Terminal settings applied"
+Assert-Exists "$h\.config\powertoys.dsc.yaml"            "PowerToys config applied"
+
+Write-Host "Cross-platform isolation (Unix-only files absent):"
+Assert-Absent "$h\.zshrc"               ".zshrc not applied on Windows"
+Assert-Absent "$h\.oh-my-zsh"           "oh-my-zsh not applied on Windows"
+Assert-Absent "$h\.local\bin\ssh-ident" "ssh-ident not applied on Windows"
+
+Write-Host ""
+if ($script:Failures -gt 0) {
+  Write-Host "$($script:Failures) assertion(s) failed." -ForegroundColor Red
+  exit 1
+}
+Write-Host "All assertions passed." -ForegroundColor Green


### PR DESCRIPTION
The workflow previously only checked that `chezmoi apply` exited 0, which can't catch a dotfile that renders wrong, an external that fails to download, or a .chezmoiignore rule that leaks files onto the wrong OS.

Add tests/verify-unix.sh and tests/verify-windows.ps1 that assert the expected target files exist after apply, that .gitconfig actually rendered from its template, that externals downloaded, and -- via negative assertions -- that platform isolation holds. Wire a verify step into all three jobs (Linux, Windows, Linux ARM64).

Plain assertion scripts (no Bats/Pester) to match the repo's dependency-free style and avoid an extra CI install step.