### PR TITLE
Add Dependabot config for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  # Keep the actions used in our workflows (e.g. actions/checkout) up to date.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"


### PR DESCRIPTION
## What

Adds `.github/dependabot.yml` watching the `github-actions` ecosystem at the repo root.

## Why

Keeps the actions used in the test/lint workflows (currently `actions/checkout`) patched automatically via weekly Dependabot PRs, prefixed with `ci` for easy identification. Dependabot only manages GitHub Actions here — it does not touch chezmoi externals.

## Notes

First of three small repo-hygiene PRs (this one, `.editorconfig`, and CI linting). Independent of the others.

🤖 Generated with [Claude Code](https://claude.com/claude-code)