### PR TITLE
Add shellcheck + PSScriptAnalyzer linting to CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,55 @@
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch: # Allow manual triggering
+
+jobs:
+  shellcheck:
+    name: ShellCheck (shell scripts)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # ShellCheck is preinstalled on GitHub-hosted Ubuntu runners.
+      # The repo's .shellcheckrc (enabled optional checks, template-directive
+      # accommodations) is picked up automatically. We gate at warning+ so the
+      # opt-in *style* checks stay as editor-only hints and don't block merges.
+      # --shell=bash is the default for files that don't self-declare a shell;
+      # per-file `# shellcheck shell=` directives still take precedence.
+      - name: Run ShellCheck
+        run: |
+          mapfile -t files < <(find home tests -type f \( -name '*.sh' -o -name '*.sh.tmpl' \))
+          shellcheck --severity=warning --shell=bash "${files[@]}" install.sh
+
+  powershell:
+    name: PSScriptAnalyzer (PowerShell scripts)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install PSScriptAnalyzer
+        shell: pwsh
+        run: Install-Module PSScriptAnalyzer -Scope CurrentUser -Force
+
+      # Analyze plain .ps1 files only. The *.ps1.tmpl files and
+      # .chezmoitemplates/powershell-setup.ps1 contain chezmoi template syntax
+      # ({{ ... }}) that isn't valid PowerShell, so they can't be parsed.
+      - name: Run PSScriptAnalyzer
+        shell: pwsh
+        run: |
+          $files = Get-ChildItem -Recurse -File home, tests -Include *.ps1 |
+            Where-Object { $_.Name -ne 'powershell-setup.ps1' }
+          $results = foreach ($f in $files) {
+            Invoke-ScriptAnalyzer -Path $f.FullName -Settings ./PSScriptAnalyzerSettings.psd1
+          }
+          if ($results) {
+            $results | Format-Table -AutoSize RuleName, Severity, ScriptName, Line, Message
+            throw "PSScriptAnalyzer found $($results.Count) issue(s)."
+          }
+          Write-Host "No PSScriptAnalyzer findings."

--- a/PSScriptAnalyzerSettings.psd1
+++ b/PSScriptAnalyzerSettings.psd1
@@ -1,0 +1,23 @@
+@{
+    # Run the default PSScriptAnalyzer rule set, minus rules that conflict with
+    # deliberate conventions in this repo. See .github/workflows/lint.yml.
+    ExcludeRules = @(
+        # Setup scripts intentionally use Write-Host for coloured, user-facing
+        # console output (progress/status), not pipeline data.
+        'PSAvoidUsingWriteHost'
+
+        # Stylistic only; these interactive-style scripts favour terse calls.
+        'PSAvoidUsingPositionalParameters'
+        'PSAvoidUsingCmdletAliases'
+
+        # Renaming functions to singular nouns would break documented commands
+        # (e.g. 'install-apps' referenced in the README).
+        'PSUseSingularNouns'
+
+        # -WhatIf/-Confirm plumbing is overkill for one-shot machine setup scripts.
+        'PSUseShouldProcessForStateChangingFunctions'
+
+        # UTF-8 without a BOM is correct for PowerShell 7 and matches .editorconfig.
+        'PSUseBOMForUnicodeEncodedFile'
+    )
+}

--- a/README.md
+++ b/README.md
@@ -92,6 +92,34 @@ Get-Content -Path /path/to/.chezmoi.yaml.tmpl | chezmoi execute-template --init
 
 `chezmoi execute-template --init` can also take `--promptString <name>=<value>` but it also applies to the `promptString` function inside a template, not to `promptStringOnce`.
 
+## Linting
+
+CI lints the shell and PowerShell scripts (see [the lint workflow](./.github/workflows/lint.yml)):
+
+- **ShellCheck** over `*.sh`/`*.sh.tmpl`, gated at `--severity=warning`. Config lives in [`.shellcheckrc`](./.shellcheckrc).
+- **PSScriptAnalyzer** over plain `*.ps1` files. Rule selection lives in [`PSScriptAnalyzerSettings.psd1`](./PSScriptAnalyzerSettings.psd1).
+
+To run the linters locally you must install the tools first; they are *not* installed by this repo.
+
+### ShellCheck
+
+Install it (Windows: `scoop install shellcheck`; macOS: `brew install shellcheck`; Debian/Ubuntu: `apt install shellcheck`), then from the repo root:
+
+```bash
+shellcheck --severity=warning --shell=bash \
+  $(find home tests -type f \( -name '*.sh' -o -name '*.sh.tmpl' \)) install.sh
+```
+
+### PSScriptAnalyzer
+
+Install the module from the PowerShell Gallery (`Install-Module PSScriptAnalyzer`), then from the repo root:
+
+```PowerShell
+Get-ChildItem -Recurse -File home, tests -Include *.ps1 |
+  Where-Object { $_.Name -ne 'powershell-setup.ps1' } |
+  ForEach-Object { Invoke-ScriptAnalyzer -Path $_.FullName -Settings ./PSScriptAnalyzerSettings.psd1 }
+```
+
 ## Notes
 
 For Windows systems, [the Windows Terminal settings][windows-terminal-settings-file] assume that the Ubuntu distribution

--- a/home/.chezmoiscripts/linux/run_after_00-copy-ssh-keys-from-wsl.sh.tmpl
+++ b/home/.chezmoiscripts/linux/run_after_00-copy-ssh-keys-from-wsl.sh.tmpl
@@ -4,7 +4,7 @@
 
 SSH_DIR=${HOME}/.ssh;
 
-if ls -A1q "${SSH_DIR}" | grep -q . ; then
+if [[ -n "$(ls -A "${SSH_DIR}")" ]]; then
   echo "'${SSH_DIR}' is not empty. Skipping copy of SSH keys from Windows.";
 	exit 0;
 fi
@@ -24,7 +24,7 @@ for f in "${WIN_SSH_DIR}"/id*; do
 done
 
 # If any files were copied, set permissions correctly.
-if ls -A1q "${SSH_DIR}" | grep -q .; then
+if [[ -n "$(ls -A "${SSH_DIR}")" ]]; then
   chmod 600 "${SSH_DIR}"/*;
 else
   echo "No SSH keys found in '${WIN_SSH_DIR}'. Nothing copied.";

--- a/home/.chezmoiscripts/windows/run_once_after_00-install-scoop.ps1
+++ b/home/.chezmoiscripts/windows/run_once_after_00-install-scoop.ps1
@@ -12,7 +12,9 @@ if (-not (Get-Command "scoop" -ErrorAction SilentlyContinue)) {
   $TmpPathToInstallScript = "$($env:TEMP)\install.ps1";
   # Use fixed version of the install script
   Invoke-RestMethod https://raw.githubusercontent.com/ScoopInstaller/Install/ff4eedda58d832b8225d7697510f097ebe8ab071/install.ps1 -OutFile $TmpPathToInstallScript;
-  Invoke-Expression "& $TmpPathToInstallScript -ScoopDir '$env:WIN_TOOLS_PATH/scoop'";
+  # Invoke the downloaded script directly with the call operator; no need for
+  # Invoke-Expression (the call operator handles a path with spaces correctly).
+  & $TmpPathToInstallScript -ScoopDir "$env:WIN_TOOLS_PATH/scoop";
   Remove-Item -Path $TmpPathToInstallScript;
 }
 

--- a/home/dot_claude/hooks/check-windows.sh
+++ b/home/dot_claude/hooks/check-windows.sh
@@ -3,7 +3,8 @@
 # inform Claude about the environment.
 
 is_windows() {
-  [[ "$OS" == "Windows_NT" ]] || [[ "$OSTYPE" == msys* ]] || [[ "$OSTYPE" == cygwin* ]]
+  # OS and OSTYPE come from the environment (Windows / shell), not this script.
+  [[ "${OS:-}" == "Windows_NT" ]] || [[ "${OSTYPE:-}" == msys* ]] || [[ "${OSTYPE:-}" == cygwin* ]]
 }
 
 is_windows || exit 0

--- a/home/ignored/zshrc-content.sh
+++ b/home/ignored/zshrc-content.sh
@@ -66,6 +66,7 @@ if [[ -n "$(command -v fnm)" ]]; then
 fi
 
 # Use fzf
+# shellcheck disable=SC1090 # Sourcing fzf's generated init; nothing to follow.
 source <(fzf --zsh)
 
 # Enable the navi widget


### PR DESCRIPTION
## What

Adds a `Lint` workflow with two jobs, plus a small set of fixes for the genuine warnings it surfaced.

- **ShellCheck** over all shell scripts (`.sh`/`.sh.tmpl` + `install.sh`), gated at `--severity=warning` so the repo's opt-in *style* rules (braces, `[[ ]]`, masked returns) stay as editor-only hints via `.shellcheckrc` and do not block merges. `--shell=bash` is the default for files that do not self-declare; per-file `# shellcheck shell=` directives still take precedence.
- **PSScriptAnalyzer** over plain `.ps1` files. Templated `*.ps1.tmpl` and the template-content `powershell-setup.ps1` contain `{{ }}` syntax that is not valid PowerShell, so they are excluded. Rule selection lives in `PSScriptAnalyzerSettings.psd1`.

## Genuine warnings fixed

- `copy-ssh-keys`: replace `ls | grep` empty-dir checks with a quoted command-substitution test (SC2010).
- `check-windows` hook: treat `$OS`/`$OSTYPE` as external env vars via `${VAR:-}` (SC2154).
- `zshrc-content`: inline-disable SC1090 for the unfollowable `source <(fzf --zsh)`.
- `install-scoop`: drop `Invoke-Expression` in favour of the call operator, which also removes fragile path quoting (PSAvoidUsingInvokeExpression).

## Notes for reviewer

- **Validated locally**: shellcheck and PSScriptAnalyzer were installed and run against the actual files — shellcheck exits 0 and PSSA reports 0 findings at the gating level.
- **PSSA exclusions beyond the obvious** (each commented in the `.psd1`): `Write-Host` (deliberate console output), positional params + aliases (style), `PSUseSingularNouns` (renaming would break the documented `install-apps`), `PSUseShouldProcessForStateChangingFunctions` (overkill for setup scripts), `PSUseBOMForUnicodeEncodedFile` (UTF-8-no-BOM is correct for pwsh 7 and matches the `.editorconfig` PR). Happy to *fix* any of these instead of excluding if preferred.
- The scoop `Invoke-Expression` change is exercised by the existing Windows install job; the Linux/ARM shellcheck behaviour runs on the runners' shellcheck (slightly older than the local 0.11).

Third of three repo-hygiene PRs. The `.psd1` comment references the `.editorconfig` rationale from #51, so suggest merging after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)