### PR TITLE
Block install commands without explicit approval in Claude sessions

### DIFF
--- a/home/dot_claude/CLAUDE.md
+++ b/home/dot_claude/CLAUDE.md
@@ -45,6 +45,27 @@ Stop and ask for clarification when:
 - The solution feels like a "hack" or "workaround"
 - You need to modify more than 3 files for a "simple" fix
 - You're unsure about the broader impact
+- You're about to install anything (see "Never Install Without Approval" below)
+
+---
+
+## Never Install Without Approval
+
+NEVER install software, packages, modules, or CLI tools without the user's
+explicit approval first. This includes `Install-Module`/`Save-Module`,
+`scoop`/`winget`/`choco`/`brew`/`apt`/`pacman`/`pip`/`cargo`/`gem`/`go` installs,
+global `npm`/`pnpm`/`yarn` packages, `dotnet tool install`, and anything similar.
+
+- Installing changes system state and has security implications.
+- The user has preferences about *how and where* things are installed (e.g. avoid
+  the default PowerShell module path, which is OneDrive-synced and syncs across
+  machines).
+- When a task needs a missing tool: STOP, say what's missing and why, propose
+  install options, and let the user decide or run it. Pre-flighting or validation
+  is never a reason to install unprompted.
+
+A `PreToolUse` hook (`~/.claude/hooks/block-installs.sh`) enforces this, but the
+rule stands regardless of tooling.
 
 ---
 

--- a/home/dot_claude/hooks/block-installs.sh
+++ b/home/dot_claude/hooks/block-installs.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# PreToolUse guard: block commands that look like they install software,
+# packages, or modules, so they are never run without the user's explicit
+# approval. Wired for the Bash and PowerShell tools in ~/.claude/settings.json.
+#
+# Exit 2 tells Claude Code to BLOCK the tool call and shows stderr to the model.
+# Bias: a false block is cheap (just ask the user); a missed install is the
+# exact failure this guard exists to prevent, so the patterns are deliberately broad.
+
+input=$(cat)
+
+# Prefer the parsed command; fall back to the raw payload if jq isn't available
+# (the raw JSON still contains the command text, so detection still works).
+if command -v jq >/dev/null 2>&1; then
+  cmd=$(printf '%s' "${input}" | jq -r '.tool_input.command // empty' 2>/dev/null)
+  [[ -z "${cmd}" ]] && cmd=${input}
+else
+  cmd=${input}
+fi
+
+# A package/module manager followed by an install-style subcommand.
+# Boundary is "start, or any non-word char" so a manager works whether it's the
+# first token (preceded by a JSON quote in raw mode) or mid-command.
+mgr_re='(^|[^[:alnum:]_])(sudo[[:space:]]+)?(scoop|winget|choco|cinst|brew|apt|apt-get|dnf|yum|pacman|zypper|apk|snap|flatpak|pipx|pip3?|gem|cargo|nix-env|go)[[:space:]]+(install|add|-S|-Sy)([[:space:]]|$)'
+# PowerShell module/package installation.
+ps_re='Install-(Module|Package|Script)|Save-Module'
+# Global JS package installs.
+js_re='(npm[[:space:]]+(install|i|add)[[:space:]].*(-g|--global))|(pnpm[[:space:]]+(add|install|i)[[:space:]].*(-g|--global))|(yarn[[:space:]]+global[[:space:]]+add)'
+# .NET global tools.
+dotnet_re='dotnet[[:space:]]+tool[[:space:]]+install'
+
+if printf '%s' "${cmd}" | grep -qiE "${mgr_re}" \
+  || printf '%s' "${cmd}" | grep -qiE "${ps_re}" \
+  || printf '%s' "${cmd}" | grep -qiE "${js_re}" \
+  || printf '%s' "${cmd}" | grep -qiE "${dotnet_re}"; then
+  {
+    echo "BLOCKED: this looks like a command that installs software/packages/modules."
+    echo "Standing rule: do NOT install anything without the user's explicit approval."
+    echo "Stop and ask the user whether and how to install it (see memory: no-install-without-approval)."
+  } >&2
+  exit 2
+fi
+
+exit 0

--- a/home/dot_claude/settings.json
+++ b/home/dot_claude/settings.json
@@ -15,6 +15,17 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash|PowerShell",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ~/.claude/hooks/block-installs.sh"
+          }
+        ]
+      }
     ]
   },
   "enabledPlugins": {},
@@ -22,6 +33,26 @@
   "autoUpdatesChannel": "latest",
   "skipAutoPermissionPrompt": true,
   "permissions": {
-    "defaultMode": "auto"
+    "defaultMode": "auto",
+    "deny": [
+      "Bash(scoop install:*)",
+      "Bash(winget install:*)",
+      "Bash(choco install:*)",
+      "Bash(brew install:*)",
+      "Bash(apt install:*)",
+      "Bash(apt-get install:*)",
+      "Bash(dnf install:*)",
+      "Bash(pacman -S:*)",
+      "Bash(npm install -g:*)",
+      "Bash(npm i -g:*)",
+      "Bash(pnpm add -g:*)",
+      "Bash(pip install:*)",
+      "Bash(pip3 install:*)",
+      "Bash(pipx install:*)",
+      "Bash(cargo install:*)",
+      "Bash(gem install:*)",
+      "Bash(go install:*)",
+      "Bash(dotnet tool install:*)"
+    ]
   }
 }


### PR DESCRIPTION
## What

Adds a guard so Claude can no longer install software/packages/modules without explicit approval.

- **`PreToolUse` hook** (`dot_claude/hooks/block-installs.sh`) wired for the `Bash` and `PowerShell` tools. It inspects the command and **blocks** (exit 2) anything that looks like an install: `scoop`/`winget`/`choco`/`brew`/`apt`/`apt-get`/`dnf`/`pacman`/`pipx?`/`gem`/`cargo`/`go`/`nix-env` install/add, `Install-Module`/`Install-Package`/`Install-Script`/`Save-Module`, global `npm`/`pnpm`/`yarn`, and `dotnet tool install`.
- **`permissions.deny`** entries in `settings.json` for common Bash installers as a complementary declarative layer.

## Why

Context: in a prior session Claude installed `shellcheck` (scoop) and `PSScriptAnalyzer` (`Install-Module`, which landed in OneDrive) without asking. The settings use `defaultMode: "auto"` + `skipAutoPermissionPrompt: true`, so **tool calls are never prompted** — the only gate was the model's judgment, which failed. A `PreToolUse` hook is the one mechanism that reliably intercepts under auto-mode. Both pieces are chezmoi-managed, so they deploy to every machine (the local Claude memory recording this rule does not sync).

## Validation

The hook was unit-tested with 15 sample payloads — every package manager blocks (exit 2), and normal commands (`git status`, `chezmoi apply`, `go build`, `npm ci`) pass through. `jq` is used when present; otherwise it greps the raw payload (the boundary pattern handles a manager appearing as the first token in the JSON).

## Notes / trade-offs

- **Bias toward false blocks.** A command that merely mentions an install string (e.g. an `echo`) may be blocked — cheap to work around (rephrase / user runs it). Missing a real install is the failure we are preventing.
- v1 has **no escape hatch**: even an approved install is blocked for Claude, so the user runs it themselves. We can add an opt-in bypass (e.g. an env flag) later if this is too rigid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)